### PR TITLE
feat: two-level collapsing navbar with motion

### DIFF
--- a/app/page.tsx
+++ b/app/page.tsx
@@ -18,7 +18,7 @@ export default function Home() {
       >
         Skip to main content
       </a>
-      <div className={cn("overflow-hidden pt-[4.75rem] lg:pt-[5.25rem]")}>
+      <div className={cn("overflow-hidden pt-16 lg:pt-37")}>
         <Navbar />
         <main id="main-content">
           <Hero />

--- a/components/layout/navbar.tsx
+++ b/components/layout/navbar.tsx
@@ -1,18 +1,29 @@
 "use client";
 
+import { motion } from "motion/react";
 import Image from "next/image";
 import Link from "next/link";
 import { useEffect, useState } from "react";
+import useMeasure from "react-use-measure";
 import { navigation } from "@/constants";
+import { useCompactScroll } from "@/hooks/use-compact-scroll";
 import { cn } from "@/lib/utils";
 import { starForgeSymbol } from "@/public/assets/index";
 import Button from "../atoms/button";
 import { HamburgerMenu } from "../design/navbar";
 import MenuSvg from "../svg/menu-svg";
 
+const navSpring = {
+  type: "spring" as const,
+  stiffness: 300,
+  damping: 35,
+};
+
 const Navbar = () => {
   const [hash, setHash] = useState<string>("hero");
   const [openNavigation, setOpenNavigation] = useState<boolean>(false);
+  const isCompact = useCompactScroll();
+  const [ctaRef, ctaBounds] = useMeasure();
 
   useEffect(() => {
     const dynamicNavbarHighlight = () => {
@@ -44,84 +55,270 @@ const Navbar = () => {
   const toggleNavigation = () => setOpenNavigation(!openNavigation);
   const handleClick = () => {
     if (!openNavigation) return;
-
     setOpenNavigation(false);
   };
 
   return (
-    <header
+    <motion.header
       className={cn(
-        "fixed top-0 left-0 z-50 w-full border-n-6 border-b lg:bg-n-8/90 lg:backdrop-blur-sm",
-        openNavigation ? "bg-n-8" : "bg-n-8/90 backdrop-blur-sm"
+        "fixed top-0 left-0 z-50 w-full",
+        openNavigation ? "bg-n-8" : "bg-n-8/80 backdrop-blur-[20px]"
       )}
+      initial={false}
+      transition={navSpring}
     >
-      <div
-        className={cn("flex items-center px-5 max-lg:py-4 lg:px-7.5 xl:px-10")}
+      {/* Row 1: Utility bar — compresses upward on scroll. Hidden on mobile. */}
+      <motion.div
+        animate={{
+          height: isCompact ? 0 : "auto",
+          opacity: isCompact ? 0 : 1,
+        }}
+        className="hidden overflow-hidden lg:block"
+        initial={false}
+        transition={navSpring}
       >
-        <Link
-          className={cn("flex w-48 items-center gap-2 xl:mr-8")}
-          href="#hero"
+        <div className="border-n-6 border-b">
+          <div className="flex min-h-14 items-center justify-between px-5 py-2 lg:px-7.5 xl:px-10">
+            <LanguageSelector />
+            {/* Invisible spacer matching the CTA buttons width */}
+            <div style={{ width: ctaBounds.width }} />
+          </div>
+        </div>
+      </motion.div>
+
+      {/* Row 2: Main navigation */}
+      <div className="border-n-6 border-b">
+        <motion.div
+          animate={{
+            paddingTop: isCompact ? 10 : 16,
+            paddingBottom: isCompact ? 10 : 16,
+          }}
+          className="flex items-center justify-between px-5 lg:px-7.5 xl:px-10"
+          initial={false}
+          transition={navSpring}
         >
-          <Image alt="StarForge" height={40} src={starForgeSymbol} width={40} />
+          {/* Left: Logo */}
+          <NavbarLogo isCompact={isCompact} />
+
+          {/* Right: Nav links + spacer for floating CTA */}
+          <div className="flex items-center">
+            <nav
+              className={cn(
+                "fixed inset-x-0 top-20 bottom-0 hidden bg-n-8 lg:static lg:flex lg:bg-transparent",
+                openNavigation ? "flex" : "hidden"
+              )}
+            >
+              <div className="relative z-2 m-auto flex flex-col items-center justify-center lg:flex-row">
+                {navigation.map((item) => (
+                  <Link
+                    aria-current={item.url === hash ? "page" : undefined}
+                    className={cn(
+                      "relative block font-code text-2xl text-n-1 uppercase transition-colors hover:text-color-1",
+                      "px-6 py-2 lg:-mr-0.25 lg:font-semibold lg:text-xs",
+                      !!item.onlyMobile && "lg:hidden",
+                      item.url === hash ? "z-2 lg:text-n-1" : "lg:text-n-1/50",
+                      "lg:leading-5 lg:hover:text-n-1 xl:px-9"
+                    )}
+                    href={item.url}
+                    key={item.id}
+                    onClick={handleClick}
+                  >
+                    {item.title}
+                  </Link>
+                ))}
+              </div>
+              <HamburgerMenu />
+            </nav>
+
+            {/* Spacer — reserves room for the floating CTA buttons when compact */}
+            <motion.div
+              animate={{ width: isCompact ? ctaBounds.width : 0 }}
+              className="hidden shrink-0 lg:block"
+              initial={false}
+              transition={navSpring}
+            />
+
+            <Button
+              aria-expanded={openNavigation}
+              aria-label="Toggle navigation menu"
+              className="ml-auto lg:hidden"
+              onClick={toggleNavigation}
+              px="px-3"
+            >
+              <MenuSvg openNavigation={openNavigation} />
+            </Button>
+          </div>
+        </motion.div>
+      </div>
+
+      {/* Floating CTA buttons — absolutely positioned, always visible.
+          Scale down slightly when compact. Like slingshot's FloatingIcons. */}
+      <div className="pointer-events-none absolute inset-x-0 top-0 hidden lg:block">
+        <div className="flex items-start justify-end px-5 py-2 lg:px-7.5 xl:px-10">
+          <div className="pointer-events-auto" ref={ctaRef}>
+            <motion.div
+              animate={{ scale: isCompact ? 0.95 : 0.8 }}
+              className="flex items-center gap-5 ps-4 xl:ps-5"
+              initial={false}
+              style={{ transformOrigin: "right center" }}
+              transition={navSpring}
+            >
+              <Link
+                className="button whitespace-nowrap text-n-1/50 transition-colors hover:text-n-1"
+                href="#signup"
+              >
+                New account
+              </Link>
+              <Button className="whitespace-nowrap" href="#login" px="px-5">
+                Sign in
+              </Button>
+            </motion.div>
+          </div>
+        </div>
+      </div>
+    </motion.header>
+  );
+};
+
+/**
+ * Logo — mirrors slingshot's desktop/logo.tsx.
+ * Container width: auto → 40px. Text opacity fades. Icon stays.
+ * GPU-pinned to prevent iOS Safari reflow during animation.
+ */
+function NavbarLogo({ isCompact }: { isCompact: boolean }) {
+  return (
+    <motion.div
+      animate={{ width: isCompact ? 40 : "auto" }}
+      className="relative h-10 shrink-0 overflow-hidden"
+      initial={false}
+      transition={navSpring}
+    >
+      <Link className="relative flex h-full items-center gap-2" href="#hero">
+        <Image
+          alt="StarForge"
+          className="shrink-0"
+          height={40}
+          src={starForgeSymbol}
+          style={{
+            transform: "translate3d(0,0,0)",
+            backfaceVisibility: "hidden",
+          }}
+          width={40}
+        />
+        <motion.div
+          animate={{ opacity: isCompact ? 0 : 1 }}
+          initial={false}
+          style={{
+            width: "max-content",
+            minWidth: "max-content",
+            flexShrink: 0,
+            transform: "translate3d(0,0,0)",
+            willChange: "opacity, transform",
+            backfaceVisibility: "hidden",
+            isolation: "isolate",
+          }}
+          transition={navSpring}
+        >
           <p className="font-extrabold font-grotesk text-2xl tracking-wide">
             StarForge
           </p>
-        </Link>
-
-        <nav
-          className={cn(
-            "fixed inset-x-0 top-20 bottom-0 hidden bg-n-8 lg:static lg:mx-auto lg:flex lg:bg-transparent",
-            openNavigation ? "flex" : "hidden"
-          )}
-        >
-          <div
-            className={cn(
-              "relative z-2 m-auto flex flex-col items-center justify-center lg:flex-row"
-            )}
-          >
-            {navigation.map((item) => (
-              <Link
-                aria-current={item.url === hash ? "page" : undefined}
-                className={cn(
-                  "relative block font-code text-2xl text-n-1 uppercase transition-colors hover:text-color-1",
-                  "lg:-mr-0.25 px-6 py-6 md:py-8 lg:font-semibold lg:text-xs",
-                  !!item.onlyMobile && "lg:hidden",
-                  item.url === hash ? "z-2 lg:text-n-1" : "lg:text-n-1/50",
-                  "lg:leading-5 lg:hover:text-n-1 xl:px-12"
-                )}
-                href={item.url}
-                key={item.id}
-                onClick={handleClick}
-              >
-                {item.title}
-              </Link>
-            ))}
-          </div>
-          <HamburgerMenu />
-        </nav>
-
-        <Link
-          className="button mr-8 hidden text-n-1/50 transition-colors hover:text-n-1 lg:block"
-          href="#signup"
-        >
-          New account
-        </Link>
-        <Button className="hidden lg:flex" href="#login">
-          Sign in
-        </Button>
-
-        <Button
-          aria-expanded={openNavigation}
-          aria-label="Toggle navigation menu"
-          className="ml-auto lg:hidden"
-          onClick={toggleNavigation}
-          px="px-3"
-        >
-          <MenuSvg openNavigation={openNavigation} />
-        </Button>
-      </div>
-    </header>
+        </motion.div>
+      </Link>
+    </motion.div>
   );
-};
+}
+
+const languages = [
+  { code: "en-GB", label: "English (UK)" },
+  { code: "en-US", label: "English (US)" },
+];
+
+function LanguageSelector() {
+  const [open, setOpen] = useState(false);
+  const [selected, setSelected] = useState(languages[0]);
+  const [btnRef, setBtnRef] = useState<HTMLButtonElement | null>(null);
+
+  const rect = btnRef?.getBoundingClientRect();
+
+  return (
+    <>
+      <button
+        aria-expanded={open}
+        aria-haspopup="listbox"
+        className="button flex items-center gap-2 rounded-lg px-1 py-1.5 text-n-1/50 transition-colors hover:text-n-1"
+        onClick={() => setOpen(!open)}
+        ref={setBtnRef}
+      >
+        <svg
+          aria-hidden="true"
+          className="size-4"
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          viewBox="0 0 24 24"
+        >
+          <path
+            d="M12 21a9 9 0 1 0 0-18 9 9 0 0 0 0 18Z"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M3.6 9h16.8M3.6 15h16.8"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+          <path
+            d="M12 3a14.1 14.1 0 0 1 4 9 14.1 14.1 0 0 1-4 9 14.1 14.1 0 0 1-4-9 14.1 14.1 0 0 1 4-9Z"
+            strokeLinecap="round"
+            strokeLinejoin="round"
+          />
+        </svg>
+        {selected.label}
+        <svg
+          aria-hidden="true"
+          className={cn("size-3 transition-transform", open && "rotate-180")}
+          fill="none"
+          stroke="currentColor"
+          strokeWidth={2}
+          viewBox="0 0 24 24"
+        >
+          <path d="m6 9 6 6 6-6" strokeLinecap="round" strokeLinejoin="round" />
+        </svg>
+      </button>
+
+      {open && rect && (
+        <>
+          <div
+            className="fixed inset-0 z-[100]"
+            onClick={() => setOpen(false)}
+          />
+          <ul
+            className="fixed z-[101] min-w-36 rounded-lg border border-n-6 bg-n-8 py-1 shadow-lg"
+            role="listbox"
+            style={{ top: rect.bottom + 4, left: rect.left }}
+          >
+            {languages.map((lang) => (
+              <li
+                aria-selected={lang.code === selected.code}
+                className={cn(
+                  "cursor-pointer px-4 py-2 text-sm transition-colors hover:bg-n-7",
+                  lang.code === selected.code ? "text-color-1" : "text-n-3"
+                )}
+                key={lang.code}
+                onClick={() => {
+                  setSelected(lang);
+                  setOpen(false);
+                }}
+                role="option"
+              >
+                {lang.label}
+              </li>
+            ))}
+          </ul>
+        </>
+      )}
+    </>
+  );
+}
 
 export default Navbar;

--- a/components/sections/hero/index.tsx
+++ b/components/sections/hero/index.tsx
@@ -16,14 +16,14 @@ const Hero = () => {
   const parallaxRef = useRef(null);
   return (
     <Section
-      className={cn("-mt-[5.25rem] pt-[12rem]")}
+      className={cn("-mt-26 pt-40")}
       crosses
-      crossesOffset="lg:translate-y-[5.25rem]"
+      crossesOffset="lg:translate-y-21"
       customPaddings
       id="hero"
     >
       <div className="container relative" ref={parallaxRef}>
-        <div className="relative z-1 mx-auto mb-16 max-w-[62rem] text-center md:mb-20 lg:mb-24">
+        <div className="relative z-1 mx-auto mb-16 max-w-248 text-center md:mb-20 lg:mb-24">
           <h1 className="h1 mb-6">
             Explore the Possibilities of&nbsp;AI&nbsp;Chatting with{" "}
             <span className="relative inline-block">
@@ -46,17 +46,15 @@ const Hero = () => {
           </Button>
         </div>
 
-        <div
-          className={cn("relative mx-auto max-w-[23rem] md:max-w-5xl xl:mb-24")}
-        >
+        <div className={cn("relative mx-auto max-w-92 md:max-w-5xl xl:mb-24")}>
           <div
             className={cn("relative z-1 rounded-2xl bg-conic-gradient p-0.5")}
           >
-            <div className={cn("relative rounded-[1rem] bg-n-8")}>
+            <div className={cn("relative rounded-2xl bg-n-8")}>
               <div className={cn("h-[1.4rem] rounded-t-[0.9rem] bg-n-10")} />
               <div
                 className={cn(
-                  "aspect-[33/40] overflow-hidden rounded-b-[0.9rem] md:aspect-[688/490] lg:aspect-[1024/490]"
+                  "aspect-33/40 overflow-hidden rounded-b-[0.9rem] md:aspect-688/490 lg:aspect-1024/490"
                 )}
               >
                 <Image
@@ -68,10 +66,10 @@ const Hero = () => {
                   width={1024}
                 />
 
-                <Generating className="absolute inset-x-4 bottom-5 md:right-auto md:bottom-8 md:left-1/2 md:w-[31rem] md:-translate-x-1/2" />
+                <Generating className="absolute inset-x-4 bottom-5 md:right-auto md:bottom-8 md:left-1/2 md:w-124 md:-translate-x-1/2" />
 
                 <ScrollParallax isAbsolutelyPositioned>
-                  <ul className="absolute bottom-[7.5rem] left-[-5.5rem] hidden rounded-2xl border border-n-1/10 bg-n-9/40 p-1 backdrop-blur xl:flex">
+                  <ul className="absolute bottom-30 -left-22 hidden rounded-2xl border border-n-1/10 bg-n-9/40 p-1 backdrop-blur-sm xl:flex">
                     {heroIcons.map((icon, index) => (
                       <li className="p-5" key={index}>
                         <Image alt="" height={24} src={icon} width={24} />
@@ -82,7 +80,7 @@ const Hero = () => {
 
                 <ScrollParallax isAbsolutelyPositioned>
                   <Notification
-                    className="absolute right-[-5.5rem] bottom-44 hidden w-72 xl:flex"
+                    className="absolute -right-22 bottom-44 hidden w-72 xl:flex"
                     title="Code generation"
                   />
                 </ScrollParallax>

--- a/hooks/use-compact-scroll.ts
+++ b/hooks/use-compact-scroll.ts
@@ -1,0 +1,28 @@
+"use client";
+
+import { useMotionValueEvent, useScroll } from "motion/react";
+import { useEffect, useState } from "react";
+
+// Hysteresis gap must exceed the utility bar height (~48px) to prevent
+// oscillation from browser scroll-anchoring when the bar collapses.
+const COMPACT_AT = 80;
+const EXPAND_AT = 20;
+
+export function useCompactScroll(): boolean {
+  const { scrollY } = useScroll();
+  const [isCompact, setIsCompact] = useState(false);
+
+  useMotionValueEvent(scrollY, "change", (latest) => {
+    setIsCompact((current) => {
+      if (!current && latest > COMPACT_AT) return true;
+      if (current && latest < EXPAND_AT) return false;
+      return current;
+    });
+  });
+
+  useEffect(() => {
+    setIsCompact(window.scrollY > COMPACT_AT);
+  }, []);
+
+  return isCompact;
+}

--- a/package.json
+++ b/package.json
@@ -41,6 +41,7 @@
     "react": "^19.2.4",
     "react-dom": "^19.2.3",
     "react-just-parallax": "^3.1.16",
+    "react-use-measure": "^2.1.7",
     "tailwind-merge": "^3.4.0"
   },
   "devDependencies": {

--- a/pnpm-lock.yaml
+++ b/pnpm-lock.yaml
@@ -35,6 +35,9 @@ importers:
       react-just-parallax:
         specifier: ^3.1.16
         version: 3.1.16(react@19.2.4)
+      react-use-measure:
+        specifier: ^2.1.7
+        version: 2.1.7(react-dom@19.2.3(react@19.2.4))(react@19.2.4)
       tailwind-merge:
         specifier: ^3.4.0
         version: 3.4.0
@@ -799,6 +802,15 @@ packages:
     peerDependencies:
       react: '>=16.8 || ^17.0.0 || ^18.0.0'
 
+  react-use-measure@2.1.7:
+    resolution: {integrity: sha512-KrvcAo13I/60HpwGO5jpW7E9DfusKyLPLvuHlUyP5zqnmAPhNc6qTRjUQrdTADl0lpPpDVU2/Gg51UlOGHXbdg==}
+    peerDependencies:
+      react: '>=16.13'
+      react-dom: '>=16.13'
+    peerDependenciesMeta:
+      react-dom:
+        optional: true
+
   react@19.2.4:
     resolution: {integrity: sha512-9nfp2hYpCwOjAN+8TZFGhtWEwgvWHXqESH8qT89AT/lWklpLON22Lc8pEtnpsZz7VmawabSU0gCjnj8aC0euHQ==}
     engines: {node: '>=0.10.0'}
@@ -1496,6 +1508,12 @@ snapshots:
       lodash.debounce: 4.0.8
       prefix: 1.0.0
       react: 19.2.4
+
+  react-use-measure@2.1.7(react-dom@19.2.3(react@19.2.4))(react@19.2.4):
+    dependencies:
+      react: 19.2.4
+    optionalDependencies:
+      react-dom: 19.2.3(react@19.2.4)
 
   react@19.2.4: {}
 


### PR DESCRIPTION
## Summary
- Add two-level navbar inspired by slingshot-bio pattern
- Row 1 (utility bar): language selector, collapses upward on scroll with spring animation
- Row 2 (main nav): logo + nav links, padding shrinks when compact
- Floating CTA buttons absolutely positioned — always visible, scale down on compact (never hidden/duplicated)
- Logo text collapses to icon-only with GPU-pinned animation (prevents iOS Safari reflow)
- Scroll detection via `useCompactScroll` hook with hysteresis (compact at 80px, expand at 20px)
- All animations use unified spring config (stiffness: 300, damping: 35)
- Language selector dropdown (English UK/US) with fixed positioning

## Test plan
- [ ] Utility bar collapses smoothly on scroll
- [ ] CTA buttons stay visible and scale down when compact
- [ ] Logo text fades out, icon remains when compact
- [ ] Scrolling back to top restores full navbar
- [ ] No jitter at scroll threshold (hysteresis working)
- [ ] Language selector dropdown opens and selects
- [ ] Mobile: utility bar hidden, hamburger menu works
- [ ] No layout shift on page content

🤖 Generated with [Claude Code](https://claude.com/claude-code)